### PR TITLE
[JENKINS-26137] Picking up possible fix for integration testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.21</version>
+        <version>2.25</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -64,6 +64,8 @@
     <properties>
         <jenkins.version>1.642.3</jenkins.version>
         <workflow-step-api-plugin.version>2.9</workflow-step-api-plugin.version>
+        <workflow-cps-plugin.version>2.30-20170324.022019-1</workflow-cps-plugin.version> <!-- TODO https://github.com/jenkinsci/workflow-cps-plugin/pull/117 -->
+        <workflow-support-plugin.version>2.14-20170324.021801-1</workflow-support-plugin.version> <!-- TODO https://github.com/jenkinsci/workflow-support-plugin/pull/35 -->
     </properties>
     <dependencies>
         <dependency>
@@ -86,23 +88,29 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.8</version>
+            <version>2.11</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>scm-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.5</version>
+            <version>1.6</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.22</version>
+            <version>${workflow-cps-plugin.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.22</version>
+            <version>${workflow-cps-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
@@ -121,13 +129,13 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.10</version>
+            <version>${workflow-support-plugin.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.10</version>
+            <version>${workflow-support-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
@@ -158,7 +166,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-scm-step</artifactId>
-            <version>2.2</version>
+            <version>2.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Subsumes #37, attempting to fix [this error](https://ci.jenkins.io/job/Plugins/job/workflow-basic-steps-plugin/job/PR-37/3/testReport/org.jenkinsci.plugins.workflow.steps/TimeoutStepTest/serialForm_2/):

```
…
Resuming build at … after Jenkins restart
No need to sleep any longer
[Pipeline] }
[Pipeline] // timeout
[Pipeline] End of Pipeline
java.lang.IllegalStateException: JENKINS-26137: Jenkins is shutting down
 at org.jenkinsci.plugins.workflow.support.pickles.serialization.RiverWriter.<init>(RiverWriter.java:92)
 at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.saveProgram(CpsThreadGroup.java:431)
 at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.saveProgram(CpsThreadGroup.java:412)
 at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:357)
 at …
```

Downstream of https://github.com/jenkinsci/workflow-support-plugin/pull/35 & https://github.com/jenkinsci/workflow-cps-plugin/pull/117.

@reviewbybees